### PR TITLE
エビデンスwebサイトへのリンク機能の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ group :test do
 end
 
 gem "cocoon"
+gem "dotenv-rails"
 gem "enum_help"
 gem "factory_bot_rails"
 gem "font-awesome-sass"

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :test do
   gem 'webdrivers', '~> 4.0'
 end
 
+gem "bitly"
 gem "cocoon"
 gem "dotenv-rails"
 gem "enum_help"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,8 @@ GEM
     arel (9.0.0)
     ast (2.4.1)
     bindex (0.8.1)
+    bitly (2.0.1)
+      oauth2 (>= 0.5.0, < 2.0)
     bootsnap (1.4.8)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -103,6 +105,9 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
+    faraday (1.1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
     ffi (1.13.1)
     font-awesome-sass (5.13.0)
       sassc (>= 1.11)
@@ -130,6 +135,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jwt (2.2.2)
     kgio (2.11.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -148,6 +154,9 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.2)
     msgpack (1.3.3)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
     mysql2 (0.5.3)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
@@ -155,6 +164,12 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    oauth2 (1.4.4)
+      faraday (>= 0.8, < 2.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
@@ -233,6 +248,7 @@ GEM
     rubocop-ast (0.4.2)
       parser (>= 2.7.1.4)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.2)
     ruby_dep (1.5.0)
     ruby_parser (3.15.0)
       sexp_processor (~> 4.9)
@@ -305,6 +321,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bitly
   bootsnap (>= 1.1.0)
   byebug
   capistrano

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,10 @@ GEM
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     diff-lcs (1.4.4)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     enum_help (0.0.17)
       activesupport (>= 3.0.0)
     erubi (1.9.0)
@@ -311,6 +315,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   cocoon
   coffee-rails (~> 4.2)
+  dotenv-rails
   enum_help
   factory_bot_rails
   font-awesome-sass

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ TwitterAPI(未実装)
 
 ## DB設計
 
-### Postsテーブル
+### postsテーブル
 
 |Column|Type|Options|
 |------|----|-------|
@@ -52,10 +52,10 @@ TwitterAPI(未実装)
 
 #### Association
 
-- belongs_to :user
-- has_many :evidences dependent: :destroy
+* belongs_to :user
+* has_many :evidences dependent: :destroy
 
-### Evidencesテーブル
+### evidencesテーブル
 
 |Column|Type|Options|
 |------|----|-------|
@@ -70,9 +70,21 @@ TwitterAPI(未実装)
 
 #### Association
 
-- belongs_to :post
+* belongs_to :post
+* has_one :short_url
 
-### Usersテーブル
+### short_urlsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|evidence|references|null: false, foreign_key: true|
+|url|string|null: false|
+
+#### Association
+
+* belongs_to :evidence
+
+### usersテーブル(未実装)
 
 |Column|Type|Options|
 |------|----|-------|
@@ -81,10 +93,10 @@ TwitterAPI(未実装)
 
 #### Association
 
-- has_one :sns_credential dependent: :destroy
-- has_many :posts dependent: destroy
+* has_one :sns_credential dependent: :destroy
+* has_many :posts dependent: destroy
 
-### SNS_credentialsテーブル
+### sns_credentialsテーブル(未実装)
 
 |Column|Type|Options|
 |------|----|-------|
@@ -93,4 +105,4 @@ TwitterAPI(未実装)
 
 #### Association
 
-- belongs_to :user optional: true
+* belongs_to :user optional: true

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ TwitterAPI(未実装)
 #### Association
 
 * belongs_to :post
-* has_one :short_url
+* has_one :short_url dependent: :destroy
 
 ### short_urlsテーブル
 

--- a/app/assets/javascripts/evidences.js
+++ b/app/assets/javascripts/evidences.js
@@ -15,7 +15,7 @@ $(document).on('turbolinks:load', function() {
   $(function(){
     // evidences一覧のアコーディオンメニュー表示・非表示イベント
     $('.evidence-info').hide();
-    $('.evidences__evidence').click(function(){
+    $('.evidences__heading').click(function(){
       $(this).next('.evidence-info').slideToggle();
     });
   });

--- a/app/assets/stylesheets/partials/evidences/_evidences_show.scss
+++ b/app/assets/stylesheets/partials/evidences/_evidences_show.scss
@@ -17,7 +17,7 @@
 }
 .evidences {
   margin: 15px 0 15px auto;
-  &__evidence {
+  &__heading {
     padding-left: 26px;
     text-indent: -13px;
     word-break: break-all;

--- a/app/controllers/evidences_controller.rb
+++ b/app/controllers/evidences_controller.rb
@@ -8,12 +8,9 @@ class EvidencesController < ApplicationController
     @post = Post.new(evidence_params)
     if @post.save
       redirect_to evidence_path(@post.id)
-      # sourceがURLのevidenceレコードは短縮URLをShort_urlsテーブルに保存
       @post.evidences.each do | evidence |
-        if URI::DEFAULT_PARSER.make_regexp.match(evidence.source).nil?
-        else
-          client = Bitly::API::Client.new(token: ENV['BITLY_TOKEN'])
-          shorturl = client.shorten(long_url: evidence.source)
+        # sourceがURLのevidenceレコードは短縮URLをShort_urlsテーブルに保存
+        if it_is_url(evidence.source)
           @short_url = ShortUrl.new({evidence_id: evidence.id,
                                       url: short_url(evidence.source)})
           # 保存ができなかったパターンの処理は未記載
@@ -29,6 +26,10 @@ class EvidencesController < ApplicationController
     @post = Post.find(params[:id])
   end
 
+  def it_is_url(source)
+    # sourceがURLの場合は返り値がTRUEになる
+    URI::DEFAULT_PARSER.make_regexp.match(source).nil? ? FALSE : TRUE
+  end
 
   def short_url(long_url)
     # bitlyのAPIを使用して短縮URLを作成

--- a/app/controllers/evidences_controller.rb
+++ b/app/controllers/evidences_controller.rb
@@ -15,7 +15,8 @@ class EvidencesController < ApplicationController
           client = Bitly::API::Client.new(token: ENV['BITLY_TOKEN'])
           shorturl = client.shorten(long_url: evidence.source)
           @short_url = ShortUrl.new({evidence_id: evidence.id,
-                                      url: shorturl.link})
+                                      url: short_url(evidence.source)})
+          # 保存ができなかったパターンの処理は未記載
           @short_url.save
         end
       end
@@ -26,6 +27,14 @@ class EvidencesController < ApplicationController
 
   def show
     @post = Post.find(params[:id])
+  end
+
+
+  def short_url(long_url)
+    # bitlyのAPIを使用して短縮URLを作成
+    client = Bitly::API::Client.new(token: ENV['BITLY_TOKEN'])
+    shorturl = client.shorten(long_url: long_url)
+    shorturl.link
   end
 
   private

--- a/app/controllers/evidences_controller.rb
+++ b/app/controllers/evidences_controller.rb
@@ -8,6 +8,17 @@ class EvidencesController < ApplicationController
     @post = Post.new(evidence_params)
     if @post.save
       redirect_to evidence_path(@post.id)
+      # sourceがURLのevidenceレコードは短縮URLをShort_urlsテーブルに保存
+      @post.evidences.each do | evidence |
+        if URI::DEFAULT_PARSER.make_regexp.match(evidence.source).nil?
+        else
+          client = Bitly::API::Client.new(token: ENV['BITLY_TOKEN'])
+          shorturl = client.shorten(long_url: evidence.source)
+          @short_url = ShortUrl.new({evidence_id: evidence.id,
+                                      url: shorturl.link})
+          @short_url.save
+        end
+      end
     else
       render :new
     end

--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -1,5 +1,6 @@
 class Evidence < ApplicationRecord
   belongs_to :post
+  has_one :short_url, dependent: :destroy
 
   enum level:{ primary: 0, secondary: 1, tertiary: 2 }
   # primary = 一次情報 secondary = 二次情報 tertiary = 三次情報

--- a/app/models/short_url.rb
+++ b/app/models/short_url.rb
@@ -1,0 +1,2 @@
+class ShortUrl < ApplicationRecord
+end

--- a/app/models/short_url.rb
+++ b/app/models/short_url.rb
@@ -1,2 +1,3 @@
 class ShortUrl < ApplicationRecord
+  belongs_to :evidence
 end

--- a/app/views/evidences/show.html.haml
+++ b/app/views/evidences/show.html.haml
@@ -10,7 +10,10 @@
         .evidences__evidence
           = icon('fas', 'caret-square-down')
           エビデンス
-          = evidence.source
+          - if URI.regexp.match(evidence.source).nil?
+            = evidence.source
+          - else
+            = link_to "#{ evidence.source }", "#{ evidence.source }", target: '_blank'
         %table.evidence-info
           %tr.evidence-info__row
             %td.evidence-info__row__title

--- a/app/views/evidences/show.html.haml
+++ b/app/views/evidences/show.html.haml
@@ -10,7 +10,7 @@
         .evidences__heading
           = icon('fas', 'caret-square-down')
           エビデンス
-          - if URI.regexp.match(evidence.source).nil?
+          - if URI::DEFAULT_PARSER.make_regexp.match(evidence.source).nil?
             = evidence.source
           - else
             = link_to "#{ evidence.source }", "#{ evidence.source }", target: '_blank'

--- a/app/views/evidences/show.html.haml
+++ b/app/views/evidences/show.html.haml
@@ -7,7 +7,7 @@
         = @post.text
     .evidences
       - @post.evidences.each do | evidence |
-        .evidences__evidence
+        .evidences__heading
           = icon('fas', 'caret-square-down')
           エビデンス
           - if URI.regexp.match(evidence.source).nil?

--- a/app/views/evidences/show.html.haml
+++ b/app/views/evidences/show.html.haml
@@ -13,7 +13,7 @@
           - if URI::DEFAULT_PARSER.make_regexp.match(evidence.source).nil?
             = evidence.source
           - else
-            = link_to "#{ evidence.source }", "#{ evidence.source }", target: '_blank'
+            = link_to "#{ evidence.short_url.url }", "#{ evidence.short_url.url }", target: '_blank'
         %table.evidence-info
           %tr.evidence-info__row
             %td.evidence-info__row__title

--- a/db/migrate/20201109165524_create_short_urls.rb
+++ b/db/migrate/20201109165524_create_short_urls.rb
@@ -1,8 +1,8 @@
 class CreateShortUrls < ActiveRecord::Migration[5.2]
   def change
     create_table :short_urls do |t|
-      t.reference :evidence
-      t.string :url
+      t.references :evidence, null: false, foreign_key: true
+      t.string :url, null: false
 
       t.timestamps
     end

--- a/db/migrate/20201109165524_create_short_urls.rb
+++ b/db/migrate/20201109165524_create_short_urls.rb
@@ -1,0 +1,10 @@
+class CreateShortUrls < ActiveRecord::Migration[5.2]
+  def change
+    create_table :short_urls do |t|
+      t.reference :evidence
+      t.string :url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_22_180447) do
+ActiveRecord::Schema.define(version: 2020_11_09_165524) do
 
   create_table "evidences", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -32,5 +32,14 @@ ActiveRecord::Schema.define(version: 2020_09_22_180447) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "short_urls", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "evidence_id", null: false
+    t.string "url", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["evidence_id"], name: "index_short_urls_on_evidence_id"
+  end
+
   add_foreign_key "evidences", "posts"
+  add_foreign_key "short_urls", "evidences"
 end

--- a/spec/factories/short_urls.rb
+++ b/spec/factories/short_urls.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :short_url do
+    evidence { "" }
+    url { "MyString" }
+  end
+end

--- a/spec/models/short_url_spec.rb
+++ b/spec/models/short_url_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ShortUrl, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## What
* Gem追加：bitly(短縮URL作成ヘルパー), dotenv-rails(環境変数設定)
* DB追加：short_urlsテーブル作成
* 機能変更：エビデンスがURLの場合はリンクにして、クリックしたら別タブでリンク先が開くようにした。リンク自体も短縮URLにした(短縮URLはevidencesテーブルと紐付いたshort_urlsテーブルに保存)。
* スクショ：https://gyazo.com/9fa75fc889e9857e8665273d1cec7ce8

## Why
* 問題：現在はエビデンスがURLで表示されるが、そのままだとURLをコピーして自分でWebサイトに移動するしかないため、手間がかかる。また、URLが長いと表示の見栄えが悪い。
* 解決方法：リンクにすることですぐにエビデンスにアクセスできる。URLが短ければ表示への影響が少なくできる。