### PR TITLE
URL短縮機能リファクタリング

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Twitterやその他SNS等では偽・誤情報が広まることも多く、コ�
 |Column|Type|Options|
 |------|----|-------|
 |post|references|null: false, foreign_key: true|
-|source|string|null: false|
+|source|text|null: false|
 |informant|string||
 |source_updated_on|date||
 |level|integer|default: null, limit:1|

--- a/app/controllers/evidences_controller.rb
+++ b/app/controllers/evidences_controller.rb
@@ -8,15 +8,6 @@ class EvidencesController < ApplicationController
     @post = Post.new(evidence_params)
     if @post.save
       redirect_to evidence_path(@post.id)
-      @post.evidences.each do | evidence |
-        # sourceがURLのevidenceレコードは短縮URLをShort_urlsテーブルに保存
-        if it_is_url(evidence.source)
-          @short_url = ShortUrl.new({evidence_id: evidence.id,
-                                      url: short_url(evidence.source)})
-          # 保存ができなかったパターンの処理は未記載
-          @short_url.save
-        end
-      end
     else
       render :new
     end
@@ -24,18 +15,6 @@ class EvidencesController < ApplicationController
 
   def show
     @post = Post.find(params[:id])
-  end
-
-  def it_is_url(source)
-    # sourceがURLの場合は返り値がTRUEになる
-    URI::DEFAULT_PARSER.make_regexp.match(source).nil? ? FALSE : TRUE
-  end
-
-  def short_url(long_url)
-    # bitlyのAPIを使用して短縮URLを作成
-    client = Bitly::API::Client.new(token: ENV['BITLY_TOKEN'])
-    shorturl = client.shorten(long_url: long_url)
-    shorturl.link
   end
 
   private

--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -19,7 +19,7 @@ class Evidence < ApplicationRecord
     errors.add(:source_updated_on, "は今日以前の日付を選択してください") if source_updated_on.present? && source_updated_on > Date.today
   end
 
-  def it_is_url
+  def it_is_url?
     URI::DEFAULT_PARSER.make_regexp.match(self.source).nil? ? FALSE : TRUE
   end
 
@@ -34,7 +34,7 @@ class Evidence < ApplicationRecord
 
   def shorten_url_create
     # self.sourceがURLの場合はTRUE
-    if self.it_is_url
+    if self.it_is_url?
       @short_url = ShortUrl.new({evidence_id: self.id,
                                   url: convert_long_url(self.source)})
       false unless @short_url.save

--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -1,4 +1,7 @@
 class Evidence < ApplicationRecord
+  # sourceがURLの場合はshort_urlsテーブルに短縮URLを別途作成する
+  after_create :shorten_url_create
+
   belongs_to :post
   has_one :short_url, dependent: :destroy
 
@@ -14,6 +17,28 @@ class Evidence < ApplicationRecord
 
   def updated_date_before_today?
     errors.add(:source_updated_on, "は今日以前の日付を選択してください") if source_updated_on.present? && source_updated_on > Date.today
+  end
+
+  def it_is_url
+    URI::DEFAULT_PARSER.make_regexp.match(self.source).nil? ? FALSE : TRUE
+  end
+
+  def convert_long_url(long_url)
+    # bitlyのAPIを使用して短縮URLを作成
+    client = Bitly::API::Client.new(token: ENV['BITLY_TOKEN'])
+    shorturl = client.shorten(long_url: long_url)
+    shorturl.link
+  end
+
+  protected
+
+  def shorten_url_create
+    # self.sourceがURLの場合はTRUE
+    if self.it_is_url
+      @short_url = ShortUrl.new({evidence_id: self.id,
+                                  url: convert_long_url(self.source)})
+      false unless @short_url.save
+    end
   end
 
 end

--- a/app/views/evidences/show.html.haml
+++ b/app/views/evidences/show.html.haml
@@ -12,8 +12,8 @@
           エビデンス
           - if evidence.short_url.count > 1
             = link_to "#{ evidence.short_url.url }", "#{ evidence.short_url.url }", target: '_blank'
-          -# 何らかの理由で短縮URLが作成できなかった場合は元のURLを表示させる
-          - elsif evidence.it_is_url
+          - elsif evidence.it_is_url?
+            -# 何らかの理由で短縮URLが作成できなかった場合は元のURLを表示させる
             = link_to "#{ evidence.source }", "#{ evidence.source }", target: '_blank'
           - else
             = evidence.source

--- a/app/views/evidences/show.html.haml
+++ b/app/views/evidences/show.html.haml
@@ -10,7 +10,7 @@
         .evidences__heading
           = icon('fas', 'caret-square-down')
           エビデンス
-          - if evidence.short_url.count > 1
+          - if evidence.short_url.present?
             = link_to "#{ evidence.short_url.url }", "#{ evidence.short_url.url }", target: '_blank'
           - elsif evidence.it_is_url?
             -# 何らかの理由で短縮URLが作成できなかった場合は元のURLを表示させる

--- a/app/views/evidences/show.html.haml
+++ b/app/views/evidences/show.html.haml
@@ -10,10 +10,13 @@
         .evidences__heading
           = icon('fas', 'caret-square-down')
           エビデンス
-          - if URI::DEFAULT_PARSER.make_regexp.match(evidence.source).nil?
-            = evidence.source
-          - else
+          - if evidence.short_url.count > 1
             = link_to "#{ evidence.short_url.url }", "#{ evidence.short_url.url }", target: '_blank'
+          -# 何らかの理由で短縮URLが作成できなかった場合は元のURLを表示させる
+          - elsif evidence.it_is_url
+            = link_to "#{ evidence.source }", "#{ evidence.source }", target: '_blank'
+          - else
+            = evidence.source
         %table.evidence-info
           %tr.evidence-info__row
             %td.evidence-info__row__title

--- a/db/migrate/20201114130414_change_data_source_to_evidence.rb
+++ b/db/migrate/20201114130414_change_data_source_to_evidence.rb
@@ -1,0 +1,5 @@
+class ChangeDataSourceToEvidence < ActiveRecord::Migration[5.2]
+  def change
+    change_column :evidences, :source, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_09_165524) do
+ActiveRecord::Schema.define(version: 2020_11_14_130414) do
 
   create_table "evidences", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "source", null: false
+    t.text "source", null: false
     t.string "informant"
     t.date "source_updated_on"
     t.integer "level", limit: 1


### PR DESCRIPTION
## What
* DB変更：Evidencesテーブルのsourceカラムをstring型からtext型に変更
* その他：Controllerに書いていた短縮URL作成の処理をevidenceモデルに移動、after_createでコールバックするようにした。また、showアクションのビューでEvidenceのURLがあっても短縮URLがない場合は元のURLをビューに表示するようにした。

## Why
* カラム型変更：String型のカラムだと長いURLの入力に対応できないため
* 処理をモデルに移動した理由：該当の処理は本来Controllerに書くべきではなく、可読性を悪くしていた。
* ビューのif分岐：API側の問題で短縮URLが作られない事態が発生しても、アプリ自体の動作に影響がない(少ない)ようにするため