### PR TITLE
エビデンス詳細ページのパフォーマンス改善

### DIFF
--- a/app/controllers/evidences_controller.rb
+++ b/app/controllers/evidences_controller.rb
@@ -14,7 +14,7 @@ class EvidencesController < ApplicationController
   end
 
   def show
-    @post = Post.find(params[:id])
+    @post = Post.includes(evidences: :short_url).find(params[:id])
   end
 
   private

--- a/app/views/evidences/_evidence.html.haml
+++ b/app/views/evidences/_evidence.html.haml
@@ -1,0 +1,41 @@
+.evidences__heading
+  = icon('fas', 'caret-square-down')
+  エビデンス
+  - if evidence.short_url.present?
+    = link_to "#{ evidence.short_url.url }", "#{ evidence.short_url.url }", target: '_blank'
+  - elsif evidence.it_is_url?
+    -# 何らかの理由で短縮URLが作成できなかった場合は元のURLを表示させる
+    = link_to "#{ evidence.source }", "#{ evidence.source }", target: '_blank'
+  - else
+    = evidence.source
+%table.evidence-info
+  %tr.evidence-info__row
+    %td.evidence-info__row__title
+      情報提供元
+    %td.evidence-info__row__data
+      = evidence.informant
+  %tr.evidence-info__row
+    %td.evidence-info__row__title
+      情報更新日
+    %td.evidence-info__row__data
+      = l(evidence.source_updated_on, formats: :default)
+  %tr.evidence-info__row
+    %td.evidence-info__row__title
+      情報レベル
+    %td.evidence-info__row__data
+      = evidence.level_i18n
+  %tr.evidence-info__row
+    %td.evidence-info__row__title
+      私見か事実か
+    %td.evidence-info__row__data
+      = evidence.fact_or_opinion_i18n
+  %tr.evidence-info__row
+    %td.evidence-info__row__title
+      データタイプ
+    %td.evidence-info__row__data
+      = evidence.data_type_i18n
+  %tr.evidence-info__row
+    %td.evidence-info__row__title
+      備考
+    %td.evidence-info__row__data
+      = evidence.reference

--- a/app/views/evidences/show.html.haml
+++ b/app/views/evidences/show.html.haml
@@ -6,48 +6,7 @@
       .evidence-scope
         = @post.text
     .evidences
-      - @post.evidences.each do | evidence |
-        .evidences__heading
-          = icon('fas', 'caret-square-down')
-          エビデンス
-          - if evidence.short_url.present?
-            = link_to "#{ evidence.short_url.url }", "#{ evidence.short_url.url }", target: '_blank'
-          - elsif evidence.it_is_url?
-            -# 何らかの理由で短縮URLが作成できなかった場合は元のURLを表示させる
-            = link_to "#{ evidence.source }", "#{ evidence.source }", target: '_blank'
-          - else
-            = evidence.source
-        %table.evidence-info
-          %tr.evidence-info__row
-            %td.evidence-info__row__title
-              情報提供元
-            %td.evidence-info__row__data
-              = evidence.informant
-          %tr.evidence-info__row
-            %td.evidence-info__row__title
-              情報更新日
-            %td.evidence-info__row__data
-              = l(evidence.source_updated_on, formats: :default)
-          %tr.evidence-info__row
-            %td.evidence-info__row__title
-              情報レベル
-            %td.evidence-info__row__data
-              = evidence.level_i18n
-          %tr.evidence-info__row
-            %td.evidence-info__row__title
-              私見か事実か
-            %td.evidence-info__row__data
-              = evidence.fact_or_opinion_i18n
-          %tr.evidence-info__row
-            %td.evidence-info__row__title
-              データタイプ
-            %td.evidence-info__row__data
-              = evidence.data_type_i18n
-          %tr.evidence-info__row
-            %td.evidence-info__row__title
-              備考
-            %td.evidence-info__row__data
-              = evidence.reference
+      = render partial: 'evidence', collection: @post.evidences, as: "evidence"
     .share
       = link_to "https://twitter.com/share?url=#{ request.url }&text=#{ @post.text } ／ 情報元はこちら", class: 'twitter-share-button', 'data-lang': "ja", 'data-size': "large", 'data-hashtags': "EviSource", target: '_blank' do
         %script{ async: "", src: "https://platform.twitter.com/widgets.js", charset: "utf-8" }


### PR DESCRIPTION
## What
- 機能変更：evidencesコントローラーのshowアクションのN+1問題を解消し、ビューの部分テンプレート化をすることで表示パフォーマンスの遅延を解消しました。

## Why
- 問題：showアクションのビューの表示に時間がかかっていた。
- 原因：インスタンス変数の定義が甘くN+1問題が起きていた。また、ビューでeachメソッドを使用していたため繰り返し処理に時間がかかっていた。
- 解決方法：includesメソッドを適切に使用しN+1問題を解消。また、renderテンプレートのcollectionオプションで部分テンプレートを呼び出すことでeachメソッドより高速にビューを表示させました。